### PR TITLE
[RHCLOUD-28623] Add types and missing fields

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -7,6 +7,19 @@ export interface KafkaTopic {
 export interface KafkaBroker {
   hostname: string;
   port: number;
+  authType: string;
+  caCert: string;
+  saslConfig: KafkaSaslConfig;
+  securityProtocol: string;
+  // https://en.wikipedia.org/wiki/Network_socket#Socket_addresses
+  socketAddress: string;
+}
+
+export interface KafkaSaslConfig {
+  username: string;
+  password: string;
+  saslMechanism: string;
+  securityProtocol: string;
 }
 
 interface Endpoint {
@@ -33,6 +46,7 @@ export interface ClowderConfig {
   webPort: number;
   metricsPort: number;
   metricsPath: string;
+  tlsCAPath: string;
   logging: {
     type: string;
     cloudwatch: {
@@ -45,6 +59,12 @@ export interface ClowderConfig {
   kafka: {
     brokers: KafkaBroker[];
     topics: KafkaTopic[];
+  };
+  inMemoryDb: {
+    hostname: string;
+    password: string;
+    port: number;
+    username: string;
   };
   database: {
     name: string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,83 @@
+export interface KafkaTopic {
+  requestedName: string;
+  name: string;
+  consumerGroupName: string;
+}
+
+export interface KafkaBroker {
+  hostname: string;
+  port: number;
+}
+
+interface Endpoint {
+  name?: string;
+  app?: string;
+  hostname?: string;
+  port?: number;
+}
+
+export interface DependencyEndpoint {
+  [key: string]: {
+    [key: string]: Endpoint;
+  };
+}
+
+export interface ObjectBucket {
+  accessKey: string;
+  secretKey: string;
+  requestedName: string;
+  name: string;
+}
+
+export interface ClowderConfig {
+  webPort: number;
+  metricsPort: number;
+  metricsPath: string;
+  logging: {
+    type: string;
+    cloudwatch: {
+      accessKeyId: string;
+      secretAccessKey: string;
+      region: string;
+      logGroup: string;
+    };
+  };
+  kafka: {
+    brokers: KafkaBroker[];
+    topics: KafkaTopic[];
+  };
+  database: {
+    name: string;
+    username: string;
+    password: string;
+    hostname: string;
+    port: number;
+    pgPass: string;
+    adminUsername: string;
+    adminPassword: string;
+    rdsCa: string;
+    sslMode: string;
+  };
+  objectStore: {
+    hostname: string;
+    port: number;
+    accessKey: string;
+    secretKey: string;
+    tls: false;
+    buckets: ObjectBucket[];
+  };
+  featureFlags: {
+    hostname: string;
+    port: number;
+  };
+  endpoints: Endpoint[];
+  privateEndpoints: Endpoint[];
+}
+
+export const LoadedConfig: ClowderConfig | undefined;
+export const KafkaTopics: Record<string, KafkaTopic>;
+export const KafkaServers: Record<string, KafkaBroker>;
+export const ObjectBuckets: Record<string, ObjectBucket>;
+export const DependencyEndpoints: Record<string, DependencyEndpoint>;
+export const PrivateDependencyEndpoints: Record<string, DependencyEndpoint>;
+export const IsClowderEnabled: () => boolean;

--- a/index.js
+++ b/index.js
@@ -43,10 +43,18 @@ class Config {
     }
 
     KafkaServers() {
-        var brokers = new(Array);
+        let brokers = [];
         if (Config.data && Config.data.kafka){
             Config.data.kafka.brokers.forEach(function (val){
-                brokers.push(val.hostname + ":" + val.port)
+                let broker = {}
+                broker.hostname = val.hostname;
+                broker.port = val.port;
+                broker.authType = val.authType;
+                broker.caCert = val.caCert;
+                broker.saslConfig = val.saslConfig;
+                broker.securityProtocol = val.securityProtocol;
+                broker.socketAddress = `${val.hostname}:${val.port}`;
+                brokers.push(broker);
             })
         }
         return brokers;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app-common-js",
-  "version": "1.4.0",
+  "version": "2.0.0",
   "description": "Clowder client for Javascript",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.4.0",
   "description": "Clowder client for Javascript",
   "main": "index.js",
+  "types": "index.d.ts",
   "scripts": {
     "test": "mocha"
   },

--- a/test.json
+++ b/test.json
@@ -1,7 +1,8 @@
 {
     "webPort": 8000,
     "metricsPort": 9000,
-    "metricsPath": "/metircs",
+    "metricsPath": "/metrics",
+    "tlsCAPath": "tlsPath",
     "logging": {
         "type": "cloudwatch",
         "cloudwatch": {
@@ -9,13 +10,14 @@
             "secretAccessKey": "SECRET_ACCESS_KEY",
             "region": "EU",
             "logGroup": "base_app"
-            }
-        },
+        }
+    },
     "kafka": {
         "brokers": [
             {
                 "hostname": "broker-host",
-                "port": 27015
+                "port": 27015,
+                "caCert": "kafkaca"
             }
         ],
         "topics": [
@@ -27,7 +29,7 @@
         ]
     },
     "database": {
-        "name": "dBaseName",
+        "name": "dbBaseName",
         "username": "username",
         "password": "password",
         "hostname": "hostname",
@@ -38,9 +40,15 @@
         "rdsCa": "ca",
         "sslMode": "verify-full"
     },
+    "inMemoryDb": {
+        "username": "username",
+        "password": "password",
+        "hostname": "hostname",
+        "port": 3131
+    },
     "objectStore": {
         "hostname": "endpoint",
-        "port" : 9292,
+        "port": 9292,
         "accessKey": "Testing",
         "secretKey": "Testing",
         "tls": false,

--- a/test/test.js
+++ b/test/test.js
@@ -10,8 +10,10 @@ describe('config()', function () {
     var config = require('../index');
     
     expect(config.LoadedConfig).to.be.not.undefined;
-    expect(config.LoadedConfig.kafka.brokers[0].port).to.be.equal(27015)
-    expect(config.KafkaTopics["originalName"].name).to.be.equal("someTopic")
+    expect(config.IsClowderEnabled()).to.be.equal(true)
+    
+    expect(config.LoadedConfig.tlsCAPath).to.be.equal("tlsPath")
+
     expect(config.DependencyEndpoints["app1"]["endpoint1"].port).to.be.equal(8000)
     expect(config.DependencyEndpoints["app2"]["endpoint2"].name).to.be.equal("endpoint2")
     expect(config.DependencyEndpoints["app2"]["endpoint2-1"].port).to.be.equal(8000)
@@ -19,12 +21,39 @@ describe('config()', function () {
     expect(config.PrivateDependencyEndpoints["app1"]["endpoint1"].port).to.be.equal(10000)
     expect(config.DependencyEndpoints["app2"]["endpoint2"].name).to.be.equal("endpoint2")
     expect(config.PrivateDependencyEndpoints["app2"]["endpoint2-1"].name).to.be.equal("endpoint2-1")
+
     expect(config.ObjectBuckets["reqname"].name).to.be.equal("name")
-    expect(config.KafkaServers[0]).to.be.equal("broker-host:27015")
+
+    expect(config.LoadedConfig.database.name).to.be.equal("dbBaseName")
+    expect(config.LoadedConfig.database.hostname).to.be.equal("hostname")
+    expect(config.LoadedConfig.database.username).to.be.equal("username")
+    expect(config.LoadedConfig.database.password).to.be.equal("password")
+    expect(config.LoadedConfig.database.port).to.be.equal(5432) 
+    expect(config.LoadedConfig.database.pgPass).to.be.equal("testing")
+    expect(config.LoadedConfig.database.adminUsername).to.be.equal("adminusername")
+    expect(config.LoadedConfig.database.adminPassword).to.be.equal("adminpassword")
+    expect(config.LoadedConfig.database.rdsCa).to.be.equal("ca")
+    expect(config.LoadedConfig.database.sslMode).to.be.equal("verify-full")
+
+
+    expect(config.LoadedConfig.kafka.brokers[0].port).to.be.equal(27015)
+    expect(config.KafkaTopics["originalName"].name).to.be.equal("someTopic")
+    expect(config.KafkaServers[0].hostname).be.equal("broker-host")
+    expect(config.KafkaServers[0].port).be.equal(27015)
+    expect(config.KafkaServers[0].caCert).to.be.equal("kafkaca")
+    expect(config.KafkaServers[0].socketAddress).to.be.equal("broker-host:27015")
+
+    expect(config.LoadedConfig.inMemoryDb.hostname).to.be.equal("hostname")
+    expect(config.LoadedConfig.inMemoryDb.username).to.be.equal("username")
+    expect(config.LoadedConfig.inMemoryDb.password).to.be.equal("password")
+    expect(config.LoadedConfig.inMemoryDb.port).to.be.equal(3131)
+
+    
+    expect(config.LoadedConfig.featureFlags.hostname).to.be.equal("ff-server.server.example.com")
+
     data = fs.readFileSync(config.LoadedConfig.rdsCa(), "utf8")
     expect(data).to.be.equal("ca")
-    expect(config.IsClowderEnabled()).to.be.equal(true)
-    expect(config.LoadedConfig.featureFlags.hostname).to.be.equal("ff-server.server.example.com")
+    
 
     delete process.env.ACG_CONFIG
   });

--- a/test/test.js
+++ b/test/test.js
@@ -1,11 +1,12 @@
-const { fileSync } = require('tmp');
 const fs = require('fs');
+const path = require('path');
 
 var expect = require('chai').expect;
 
 describe('config()', function () {
   it('should have the right config', function () {
     
+    process.env.ACG_CONFIG = path.resolve(__dirname, '../test.json')
     var config = require('../index');
     
     expect(config.LoadedConfig).to.be.not.undefined;
@@ -24,5 +25,7 @@ describe('config()', function () {
     expect(data).to.be.equal("ca")
     expect(config.IsClowderEnabled()).to.be.equal(true)
     expect(config.LoadedConfig.featureFlags.hostname).to.be.equal("ff-server.server.example.com")
+
+    delete process.env.ACG_CONFIG
   });
 });


### PR DESCRIPTION
Using #9 as a base and adding on top of it. Note: because of the way Kafka strings were handled previously, this version will include BREAKING changes and need to move to `2.0`.

* Includes Kafka updates and other missing fields for js
* Adds typescript types 
* Checks for `ACG_CONFIG` file